### PR TITLE
Add FlexiTimer2 library

### DIFF
--- a/configs/flexitimer2.json
+++ b/configs/flexitimer2.json
@@ -1,0 +1,24 @@
+{
+  "name": "FlexiTimer2",
+  "keywords": "timer, callback",
+  "description": "Arduino library to use timer 2 with a configurable resolution. Based on MsTimer2 by Javier Valencia. Written for the project associated with the \"Mobile & Pervasive Computing\" course at Hasselt University in Belgium.",
+  "repository": {
+    "type": "git",
+    "url": "https://github.com/PaulStoffregen/FlexiTimer2.git"
+  },
+  "authors": [{
+    "name": "Wim Leers",
+    "url": "http://wimleers.com/"
+  }, {
+    "name": "Paul Stoffregen",
+    "url": "https://www.pjrc.com/about/",
+    "maintainer": true
+  }],
+  "frameworks": [
+    "arduino"
+  ],
+  "platforms": [
+    "atmelavr",
+    "teensy"
+  ]
+}


### PR DESCRIPTION
I could have use the following download links http://www.pjrc.com/teensy/arduino_libraries/FlexiTimer2.zip but preferred download them directly from the Github project.
I have also some doubts about `version`, `frameworks` and `platforms` values, information are a bit sparse on the internet :)
